### PR TITLE
chore: refresh homepage and dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 .compact-inc.cirru
 .calcit-error.cirru
+.calcit/
 
 js-out/
 node_modules/

--- a/202608121515-type-slot.md
+++ b/202608121515-type-slot.md
@@ -1,0 +1,6 @@
+# Type slot 修复记录
+
+- 为默认 JS entry 绑定 `:dispatch-op` 到 `app.schema/Op`，让 Respo 的 dispatcher callback 使用明确的应用事件类型。
+- 新增 `app.schema/Op`，覆盖页面状态切换、reel 操作与 hydrate storage 事件；snippet tabs 改为构造 `Op` 后交给事件 dispatcher。
+- 为 `app.main/dispatch!` 增加 `Fn(*dispatch-op) -> Unit` schema。
+- 静态检查暴露出依赖 `respo-ui.comp/comp-tabs` 中的 Calcit TypeRef/TypeSlot 匹配告警；该编译器问题未在本次站点变更中用未经验证的全局修改掩盖。

--- a/README.md
+++ b/README.md
@@ -12,12 +12,8 @@ Libraries:
 
 | Package                   | Version                                                                |
 | ------------------------- | ---------------------------------------------------------------------- |
-| calcit-lang/lilac-parser  | ![](https://img.shields.io/github/v/release/calcit-lang/lilac-parser)  |
-| calcit-lang/lilac         | ![](https://img.shields.io/github/v/release/calcit-lang/lilac)         |
 | calcit-lang/bisection-key | ![](https://img.shields.io/github/v/release/calcit-lang/bisection-key) |
-| calcit-lang/memof         | ![](https://img.shields.io/github/v/release/calcit-lang/memof)         |
 | calcit-lang/recollect     | ![](https://img.shields.io/github/v/release/calcit-lang/recollect)     |
-| calcit-lang/calcit-test   | ![](https://img.shields.io/github/v/release/calcit-lang/calcit-test)   |
 | calcit-lang/quaternion    | ![](https://img.shields.io/github/v/release/calcit-lang/quaternion)    |
 | calcit-lang/stir-template | ![](https://img.shields.io/github/v/release/calcit-lang/stir-template) |
 | Cirru/respo-cirru-editor  | ![](https://img.shields.io/github/v/release/Cirru/respo-cirru-editor)  |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 ## Calcit Home Page
 
+The Calcit homepage presents the current 0.13.11 direction: a typed Lisp with nominal `Struct`/`Enum` data, explicit `Option`/`Result` APIs, typed JavaScript boundaries, and a structural `cr` workflow for human and AI-assisted development.
+
+Recent Calcit releases also make the source snapshot a safer program boundary. `calcit.cirru` supports strict Cirru EDN workflows, `cr` can inspect and mutate definitions structurally, and verification can combine type analysis, examples, attached tests, and JavaScript code generation.
+
 Toolchain:
 
 | Package  | Version                                                           |

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -3,7 +3,7 @@
   :entries $ {}
     :default $ {} (:description |) (:init-fn 'app.main/main!) (:mode :js) (:reload-fn 'app.main/reload!)
       :modules $ [] |respo.calcit/ |respo-ui.calcit/ |respo-markdown.calcit/ |reel.calcit/
-      :type-slots $ {}
+      :type-slots $ {} (:dispatch-op |app.schema/Op)
   :files $ {}
     |app.comp.container $ %{} 'FileEntry
       :defs $ {}
@@ -157,7 +157,8 @@
                       :style $ {} (:margin-top 20) (:padding "|0 8px") (:min-width 160)
                     [] (&{} :name :match :title "|Pattern matching") (&{} :name :component :title |Component) (&{} :name :persistent-data :title "|Persistent data") (&{} :name :pipeline :title "|Pipeline macro")
                     fn (info d!)
-                      d! cursor $ option:unwrap-or (nth info 1) nil
+                      d! $ %:: app.schema/Op :states cursor
+                        option:unwrap-or (nth info 1) nil
                   comp-cirru-snippet $ trim (pick-demo state)
           :examples $ []
           :schema $ :: 'Dynamic
@@ -360,7 +361,9 @@
                 println |Dispatch: op
               reset! *reel $ reel-updater updater @*reel op
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ [] '*dispatch-op
         |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! ()
@@ -433,6 +436,11 @@
             |bottom-tip :default hud!
     |app.schema $ %{} 'FileEntry
       :defs $ {}
+        |Op $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defenum Op (:states 'List 'Dynamic) (:hydrate-storage 'Dynamic) (:reel/toggle) (:reel/recall 'Number) (:reel/merge) (:reel/reset) (:reel/step) (:reel/run) (:reel/remove 'Number)
+          :examples $ []
+          :schema $ :: 'Dynamic
         |doc-columns $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def doc-columns $ []

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -157,7 +157,7 @@
                       :style $ {} (:margin-top 20) (:padding "|0 8px") (:min-width 160)
                     [] (&{} :name :match :title "|Pattern matching") (&{} :name :component :title |Component) (&{} :name :persistent-data :title "|Persistent data") (&{} :name :pipeline :title "|Pipeline macro")
                     fn (info d!)
-                      d! cursor $ nth info 1
+                      d! cursor $ option:unwrap-or (nth info 1) nil
                   comp-cirru-snippet $ trim (pick-demo state)
           :examples $ []
           :schema $ :: 'Dynamic

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,17 +1,19 @@
 
-{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |app)
-  :configs $ {} (:init-fn |app.main/main!) (:reload-fn |app.main/reload!) (:version |0.0.1)
-    :modules $ [] |respo.calcit/ |lilac/ |memof/ |respo-ui.calcit/ |respo-markdown.calcit/ |reel.calcit/
+{} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |app) (:version |0.0.1)
   :entries $ {}
+    :default $ {} (:description |) (:init-fn 'app.main/main!) (:mode :native) (:reload-fn 'app.main/reload!)
+      :modules $ [] |respo.calcit/ |lilac/ |memof/ |respo-ui.calcit/ |respo-markdown.calcit/ |reel.calcit/
+      :type-slots $ {}
   :files $ {}
-    |app.comp.container $ %{} :FileEntry
+    |app.comp.container $ %{} 'FileEntry
       :defs $ {}
-        |add-link $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |add-link $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn add-link (title url)
               a $ {} (:inner-text title) (:class-name css/link) (:href url) (:target |_blank)
           :examples $ []
-        |comp-bg $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |comp-bg $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-bg ()
               ; img $ {} (:src |http://cdn.tiye.me/logo/calcit.png)
@@ -19,14 +21,20 @@
               div $ {}
                 :class-name $ str-spaced |tile style-bg
           :examples $ []
-        |comp-container $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |comp-container $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-container (reel)
               let
-                  store $ :store reel
-                  states $ :states store
-                  cursor $ either (:cursor states) ([])
-                  state $ either (:data states)
+                  store $ read-field reel :store
+                  states $ read-field store :states
+                  cursor $ either
+                      read-field states :cursor
+                      , states
+                    []
+                  state $ either
+                      read-field states :data
+                      , states
                     {} $ :content |
                 div
                   {} $ :class-name (str-spaced css/preset css/global)
@@ -50,11 +58,11 @@
                               :style $ {} (:max-width |100%)
                             div
                               {} $ :class-name style-main-title
-                              <> "|Calcit: Lisp compiling to JavaScript ES Modules"
+                              <> "|Calcit 0.13.11: typed Lisp for JavaScript ES Modules"
                             =< nil 4
                             div
                               {} $ :class-name style-secondary-title
-                              <> "|an interpreter and JavaScript emitter, AI Agent friendly via `cr` CLI tools."
+                              <> "|A Rust interpreter and JavaScript emitter with typed data, Option, Struct, Enum, and AI-friendly `cr` CLI tools."
                         =< nil 8
                         =< nil 24
                         comp-snippet-demo $ >> states :snippets
@@ -101,12 +109,13 @@
                       =< nil 120
                       div
                         {} $ :class-name css/row-parted
-                        div nil
+                        div $ {}
                         div ({}) (add-link "|GitHub calcit-lang" |http://github.com/calcit-lang/) (=< 16 nil) (add-link |Discussions |https://github.com/calcit-lang/calcit/discussions)
                       =< nil 40
                   when dev? $ comp-reel (>> states :reel) reel ({})
           :examples $ []
-        |comp-link $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |comp-link $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-link (link)
               match link $
@@ -117,7 +126,8 @@
                   if (some? sub-title)
                     <> sub-title $ str-spaced css/font-fancy style-sub-title
           :examples $ []
-        |comp-promotions $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |comp-promotions $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-promotions () $ div
               {} (:class-name css/row-parted)
@@ -138,12 +148,16 @@
                   :class-name $ str-spaced css/button style-promo-button style-main-button
                   :on-click $ fn (e d!) (js/window.open |https://repo.calcit-lang.org/calcit/docs/CalcitAgent.md |_blank)
           :examples $ []
-        |comp-snippet-demo $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |comp-snippet-demo $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-snippet-demo (states)
               let
-                  cursor $ :cursor states
-                  state $ either (:data states) :match
+                  cursor $ read-field states :cursor
+                  state $ either
+                      either (read-field states :data) :match
+                      , states
+                    , :match
                 div
                   {} (:class-name css/row)
                     :style $ {} (:flex-wrap :wrap)
@@ -158,7 +172,8 @@
                     {} $ :style
                       {} (:flex 1) (:margin "|12px 0px")
           :examples $ []
-        |comp-visual $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |comp-visual $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-visual () $ div ({})
               div ({}) (<> "|Visual of Calcit Editor:")
@@ -167,62 +182,75 @@
                   {} $ :display :flex
                 img $ {} (:class-name style-editor-img) (:src |https://cos-sh.tiye.me/cos-up/00c992c3061ed59d8c7d533b7a31433b-calcit-editor.png)
           :examples $ []
-        |demo-component $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |demo-component $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def demo-component $ inline-content! |content/demo/comp.cirru
           :examples $ []
-        |demo-match $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |demo-match $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def demo-match $ inline-content! |content/demo/match.cirru
           :examples $ []
-        |demo-persistent-data $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |demo-persistent-data $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def demo-persistent-data $ inline-content! |content/demo/persistent-data.cirru
           :examples $ []
-        |demo-pipeline $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |demo-pipeline $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def demo-pipeline $ inline-content! |content/demo/pipeline.cirru
           :examples $ []
-        |inline-content! $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |inline-content! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defmacro inline-content! (path) (read-file path)
           :examples $ []
-        |pick-demo $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |pick-demo $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn pick-demo (k)
               case-default k demo-match (:match demo-match) (:pipeline demo-pipeline) (:component demo-component) (:persistent-data demo-persistent-data)
           :examples $ []
-        |style-bg $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |style-bg $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle style-bg $ {}
               |& $ {} (:width |100vw) (:z-index |-10) (:position :fixed) (:opacity |0.5)
           :examples $ []
-        |style-cards-containers $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |style-cards-containers $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle style-cards-containers $ {}
               |& $ {} (:display :grid) (:grid-template-columns "|repeat(auto-fit, minmax(300px, 1fr))") (:gap |20px) (:margin "|32px 0")
           :examples $ []
-        |style-columns $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |style-columns $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle style-columns $ {}
               |& $ {} (:display :grid) (:grid-template-columns "|repeat(auto-fit, minmax(300px, 1fr))") (:gap |12px)
           :examples $ []
-        |style-content $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |style-content $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle style-content $ {}
               |& $ {} (:margin "|0 auto") (:max-width |1200px) (:padding "|0 40px")
           :examples $ []
-        |style-display-link $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |style-display-link $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle style-display-link $ {}
               |& $ {} (:text-decoration :none)
           :examples $ []
-        |style-editor-img $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |style-editor-img $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle style-editor-img $ {}
               |& $ {} (:max-width "|min(100%, 720px)") (:margin :auto)
           :examples $ []
-        |style-feature $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |style-feature $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle style-feature $ {}
               |& $ {} (:border-radius |12px)
@@ -236,7 +264,8 @@
               |&:hover $ {}
                 :box-shadow $ str "|1px 2px 4px " (hsl 0 0 0 0.2)
           :examples $ []
-        |style-feature-content $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |style-feature-content $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle style-feature-content $ {}
               |& $ {} (:line-height |1.7) (:font-size |15px)
@@ -244,12 +273,14 @@
                 ; :font-family ui/font-fancy
                 :font-weight 100
           :examples $ []
-        |style-feature-title $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |style-feature-title $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle style-feature-title $ {}
               |& $ {} (:font-size |16px) (:font-weight |900)
           :examples $ []
-        |style-main-button $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |style-main-button $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle style-main-button $ {}
               |button& $ {} (:color :white)
@@ -262,29 +293,34 @@
               |button&:active $ {} (:color :white)
                 :background-color $ hsl 220 80 70
           :examples $ []
-        |style-main-title $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |style-main-title $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle style-main-title $ {}
               |& $ {} (:font-size |32px) (:line-height |1.2) (:letter-spacing |-0.5px) (:font-family "|Federo, cursive")
           :examples $ []
-        |style-promo-button $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |style-promo-button $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle style-promo-button $ {}
               |& $ {} (:line-height |40px) (:border-radius |24px) (:padding "|0 24px") (:font-size |15px) (; :font-family "|Federo, cursive")
           :examples $ []
-        |style-secondary-title $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |style-secondary-title $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle style-secondary-title $ {}
               |& $ {} (:font-size |16px) (:line-height |1.6)
                 :color $ hsl 0 0 40
           :examples $ []
-        |style-sub-title $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |style-sub-title $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle style-sub-title $ {}
               |& $ {}
                 :color $ hsl 0 0 50
           :examples $ []
-      :ns $ %{} :NsEntry (:doc |)
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.comp.container $ :require (respo-ui.core :as ui)
             respo.util.format :refer $ hsl
@@ -298,9 +334,10 @@
             respo-ui.css :as css
             app.schema :refer $ doc-features doc-columns
             respo-ui.comp :refer $ comp-tabs comp-cirru-snippet
-    |app.config $ %{} :FileEntry
+            reel.schema :refer $ read-field
+    |app.config $ %{} 'FileEntry
       :defs $ {}
-        |cdn? $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |cdn? $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def cdn? $ cond
                 exists? js/window
@@ -308,22 +345,26 @@
               (exists? js/process) (= |true js/process.env.cdn)
               :else false
           :examples $ []
-        |dev? $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |dev? $ %{} 'CodeEntry (:doc |)
           :code $ quote (def dev? true)
           :examples $ []
-        |site $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |site $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def site $ {} (:dev-ui |http://localhost:8100/main-fonts.css) (:release-ui |http://cdn.tiye.me/favored-fonts/main-fonts.css) (:cdn-url |http://cdn.tiye.me/calcit-workflow/) (:title |Calcit) (:icon |http://cdn.tiye.me/logo/mvc-works.png) (:storage-key |workflow)
           :examples $ []
-      :ns $ %{} :NsEntry (:doc |)
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns app.config)
-    |app.main $ %{} :FileEntry
+    |app.main $ %{} 'FileEntry
       :defs $ {}
-        |*reel $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |*reel $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defatom *reel $ -> reel-schema/reel (assoc :base schema/store) (assoc :store schema/store)
           :examples $ []
-        |dispatch! $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |dispatch! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn dispatch! (op)
               when
@@ -331,7 +372,8 @@
                 println |Dispatch: op
               reset! *reel $ reel-updater updater @*reel op
           :examples $ []
-        |main! $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |main! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn main! ()
               println "|Running mode:" $ if config/dev? |dev |release
@@ -347,16 +389,19 @@
               println "|App started."
               println "|@@@@@@@@@@@@@@@@\n@\n@  Well, code is not minified on purpose~\n@\n@   although it's still bundled with Vite.\n@\n@@@@@@@@@@@@@@@@"
           :examples $ []
-        |mount-target $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |mount-target $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def mount-target $ js/document.querySelector |.app
           :examples $ []
-        |persist-storage! $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |persist-storage! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn persist-storage! () $ .setItem js/localStorage (:storage-key config/site)
               js/JSON.stringify $ to-cirru-edn (:store @*reel)
           :examples $ []
-        |reload! $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () $ if (nil? build-errors)
               do (remove-watch *reel :changes) (clear-cache!)
@@ -365,11 +410,13 @@
                 hud! |ok~ |Ok
               hud! |error build-errors
           :examples $ []
-        |render-app! $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |render-app! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn render-app! () $ render! mount-target (comp-container @*reel) dispatch!
           :examples $ []
-        |repeat! $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |repeat! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn repeat! (duration cb)
               js/setTimeout
@@ -377,11 +424,13 @@
                   repeat! (* 1000 duration) cb
                 * 1000 duration
           :examples $ []
-        |snippets $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |snippets $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn snippets () $ println config/cdn?
           :examples $ []
-      :ns $ %{} :NsEntry (:doc |)
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.main $ :require
             respo.core :refer $ render! clear-cache! realize-ssr!
@@ -394,9 +443,9 @@
             app.config :as config
             |./calcit.build-errors :default build-errors
             |bottom-tip :default hud!
-    |app.schema $ %{} :FileEntry
+    |app.schema $ %{} 'FileEntry
       :defs $ {}
-        |doc-columns $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |doc-columns $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def doc-columns $ []
               :: :column |Libraries $ [] (:: :link |Memof "|memoization library with caching" |https://github.com/calcit-lang/memof) (:: :link |Lilac "|validation library" |https://github.com/calcit-lang/lilac) (:: :link |Recollect "|Diff/patch library designed for Cumulo project" |https://github.com/calcit-lang/recollect) (:: :link "|Calcit WSS" "|WebSocket server binding" |https://github.com/calcit-lang/calcit-wss) (:: :link |Quaternion "|Quaternion math helper" |https://github.com/calcit-lang/quaternion) (:: :link |Std "|Some standard functions" |https://github.com/calcit-lang/calcit.std)
@@ -406,21 +455,24 @@
               :: :column |Videos $ [] (:: :link "|Calcit 更新记录: schema 类型标注, defstruct defenum 等" nil |https://www.bilibili.com/video/BV1SRw4z7ENg/) (:: :link "|Calcit 更新记录: Traits" nil |https://www.bilibili.com/video/BV1JWF9ziEpc/) (:: :link "|Calcit 更新记录: 类型标注相关的思考" nil |https://www.bilibili.com/video/BV18DzDBZExw/) (:: :link "|Calcit 语言依赖命令行接入 AI 代码生成的探索" nil |https://www.bilibili.com/video/BV1Rbv6BtE48/) (:: :link "|Calcit 近期更新, 文字外延等" nil |https://www.bilibili.com/video/BV1TMRuB3EtQ/) (:: :link "|Respo 更新记录: 组件级监听器的说明" nil |https://www.bilibili.com/video/BV1JAkFBzECf/) (:: :link "|Calcit 开发记录: list-match 语法" nil |https://www.bilibili.com/video/BV1Su4y1X7kg/) (:: :link "|Calcit 0.7 变更记录, Tag, Tuple 和多态" nil |https://www.bilibili.com/video/BV11L411v7Vk/)
               :: :column |Articles $ [] (:: :link "|Calcit 相比 Clojure 一些有意思的元编程能力 #226" nil |https://github.com/calcit-lang/calcit/discussions/226) (:: :link "|design decision: rename \"keyword\" to \"tag\" #209" nil |https://github.com/calcit-lang/calcit/discussions/209) (:: :link "|Calcit 脚本语言一些基础介绍" nil |https://zhuanlan.zhihu.com/p/394791973) (:: :link "|Introducing calcit-js: toy language inspired by cljs" nil |https://clojureverse.org/t/introducing-calcit-js-toy-language-inspired-by-cljs/7097) (:: :link "|An indentation way to Lisp" nil |https://github.com/calcit-lang/calcit-runner/discussions/123) (:: :link "|Problems encountered in generating js" nil |https://github.com/calcit-lang/calcit-runner.nim/discussions/148) (:: :link "|calcit-js 的 JavaScript 代码生成与疑难" nil |https://github.com/calcit-lang/calcit-runner.nim/discussions/184) (:: :link "|ternary-tree.ts: 关于初期的性能优化(on early optimizations)" nil |https://github.com/calcit-lang/ternary-tree.ts/discussions/7) (:: :link "|A trick for cheaper persistent list in JavaScript" nil |https://clojureverse.org/t/a-trick-for-cheaper-persistent-list-in-javascript/7172)
           :examples $ []
-        |doc-features $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |doc-features $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            def doc-features $ [] (:: :feature "|AI-friendly CLI" "|Calcit provides rich CLI commands like `cr query`, `cr tree` and `cr edit` to interact with its AST. AI Agents can read, search, and modify code deterministically—no indentation errors, no context guessing.") (:: :feature |Immutable "|Values and states are represented in different data structures, which is the semantics from functional programming. Internally it's [rpds](https://docs.rs/rpds/) in Rust and a custom [2-3 tree](https://github.com/calcit-lang/ternary-tree.ts) in JavaScript.") (:: :feature "|Lisp(Code is Data)" "|Calcit-js was designed based on experiences from ClojureScript, with a bunch of builtin macros. It offers similar experiences to ClojureScript. So Calcit offers much power via macros, while keeping its core simple.") (:: :feature "|Indentations-based Syntax" "|With `cr` command, Calcit code can be written as an indentation-based language. So you don't have to match parentheses like in Clojure. It also means now you need to handle indentations very carefully.") (:: :feature "|Hot code swapping" "|Calcit was built with hot swapping in mind. It watches code changes and re-runs the program on updates. For calcit-js, it works with Vite to reload, learning from Elm, ClojureScript and React.") (:: :feature "|ES Modules Syntax" "|To leverage the power of modern browsers with help of Vite, we need another ClojureScript that emits `import`/`export` for Vite. Calcit-js does this! And this page is built with Calcit-js as well, open Console to find out more.")
+            def doc-features $ [] (:: :feature "|AI-friendly structural CLI" "|Calcit exposes query, tree, edit, and analysis commands for deterministic structural programming. AI Agents can inspect and modify snapshots without guessing indentation.") (:: :feature "|Typed persistent data" "|Typed Struct and Enum values, persistent collections, and Option/Result make data boundaries explicit across native Rust and generated JavaScript.") (:: :feature "|Lisp and macros" "|Calcit keeps code as data and uses macros for expressive, composable programs inspired by ClojureScript, while the core stays small.") (:: :feature "|Indentation-based syntax" "|Write Calcit with indentation instead of balancing parentheses; the cr formatter and structural tools keep the snapshot consistent.") (:: :feature "|Hot code swapping" "|Calcit was built with hot swapping in mind. It watches code changes and re-runs the program on updates. For calcit-js, it works with Vite to reload, learning from Elm, ClojureScript and React.") (:: :feature "|ES Modules output" "|Calcit emits modern ES Modules for Vite and browsers, and this page is built with the same Calcit-to-JavaScript pipeline.")
           :examples $ []
-        |store $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+          :schema $ :: 'Dynamic
+        |store $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def store $ {}
               :states $ {}
                 :cursor $ []
           :examples $ []
-      :ns $ %{} :NsEntry (:doc |)
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns app.schema)
-    |app.updater $ %{} :FileEntry
+    |app.updater $ %{} 'FileEntry
       :defs $ {}
-        |updater $ %{} :CodeEntry (:doc |) (:schema :dynamic)
+        |updater $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn updater (store op op-id op-time)
               match op
@@ -428,7 +480,8 @@
                 (:hydrate-storage d) d
                 _ $ do (eprintln "|Unknown op:" op) store
           :examples $ []
-      :ns $ %{} :NsEntry (:doc |)
+          :schema $ :: 'Dynamic
+      :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.updater $ :require
             [] respo.cursor :refer $ [] update-states

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -59,11 +59,11 @@
                               :style $ {} (:max-width |100%)
                             div
                               {} $ :class-name style-main-title
-                              <> "|Calcit 0.13.11: typed Lisp for JavaScript ES Modules"
+                              <> "|Calcit 0.13.11: typed Lisp, native runtime, JavaScript ES Modules"
                             =< nil 4
                             div
                               {} $ :class-name style-secondary-title
-                              <> "|A Rust interpreter and JavaScript emitter with typed data, Option, Struct, Enum, and AI-friendly `cr` CLI tools."
+                              <> "|Struct, Enum, Option, Result, typed FFI, and a structural `cr` workflow for reliable programs and AI agents."
                         =< nil 8
                         =< nil 24
                         comp-snippet-demo $ >> states :snippets
@@ -453,7 +453,7 @@
           :schema $ :: 'Dynamic
         |doc-features $ %{} 'CodeEntry (:doc |)
           :code $ quote
-            def doc-features $ [] (:: :feature "|AI-friendly structural CLI" "|Calcit exposes query, tree, edit, and analysis commands for deterministic structural programming. AI Agents can inspect and modify snapshots without guessing indentation.") (:: :feature "|Typed persistent data" "|Typed Struct and Enum values, persistent collections, and Option/Result make data boundaries explicit across native Rust and generated JavaScript.") (:: :feature "|Lisp and macros" "|Calcit keeps code as data and uses macros for expressive, composable programs inspired by ClojureScript, while the core stays small.") (:: :feature "|Indentation-based syntax" "|Write Calcit with indentation instead of balancing parentheses; the cr formatter and structural tools keep the snapshot consistent.") (:: :feature "|Hot code swapping" "|Calcit was built with hot swapping in mind. It watches code changes and re-runs the program on updates. For calcit-js, it works with Vite to reload, learning from Elm, ClojureScript and React.") (:: :feature "|ES Modules output" "|Calcit emits modern ES Modules for Vite and browsers, and this page is built with the same Calcit-to-JavaScript pipeline.")
+            def doc-features $ [] (:: :feature "|Typed structural tooling" "|Calcit exposes query, tree, edit, cursor, transaction, and analysis commands for deterministic inspect-edit-verify workflows. They are designed for people and AI agents.") (:: :feature "|Nominal typed data" "|Struct and Enum make data boundaries explicit; Option and Result model absence and failure while persistent collections keep values ergonomic across Rust and JavaScript.") (:: :feature "|Typed JavaScript boundaries" "|Typed host-FFI contracts and static JavaScript field access carry type evidence across ES Module boundaries, with explicit escape hatches for dynamic interop.") (:: :feature "|Option-first APIs" "|Use Option<T> instead of nil for absence. Trailing Option parameters can be omitted and receive None, while non-trailing options stay explicit.") (:: :feature "|Lisp, macros, and persistent data" "|Calcit keeps code as data with an indentation-based Cirru syntax, functional collections, macros, and a compact runtime inspired by ClojureScript.") (:: :feature "|Native and ES Module output" "|Run once or watch with cr, then emit readable JavaScript ES Modules for Vite, browsers, and Node.js with matching semantics.")
           :examples $ []
           :schema $ :: 'Dynamic
         |store $ %{} 'CodeEntry (:doc |)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -22,13 +22,6 @@
                 :class-name $ str-spaced |tile style-bg
           :examples $ []
           :schema $ :: 'Dynamic
-        |comp-cirru-snippet-safe $ %{} 'CodeEntry (:doc |)
-          :code $ quote
-            defcomp comp-cirru-snippet-safe (text)
-              div ({})
-                pre ({}) (<> text)
-          :examples $ []
-          :schema $ :: 'Dynamic
         |comp-container $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-container (reel)
@@ -165,7 +158,7 @@
                     [] (&{} :name :match :title "|Pattern matching") (&{} :name :component :title |Component) (&{} :name :persistent-data :title "|Persistent data") (&{} :name :pipeline :title "|Pipeline macro")
                     fn (info d!)
                       d! cursor $ nth info 1
-                  comp-cirru-snippet-safe $ trim (pick-demo state)
+                  comp-cirru-snippet $ trim (pick-demo state)
           :examples $ []
           :schema $ :: 'Dynamic
         |comp-visual $ %{} 'CodeEntry (:doc |)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -22,6 +22,13 @@
                 :class-name $ str-spaced |tile style-bg
           :examples $ []
           :schema $ :: 'Dynamic
+        |comp-cirru-snippet-safe $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defcomp comp-cirru-snippet-safe (text)
+              div ({})
+                pre ({}) (<> text)
+          :examples $ []
+          :schema $ :: 'Dynamic
         |comp-container $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-container (reel)
@@ -75,10 +82,10 @@
                                   <> title
                                 div
                                   {} $ :class-name style-feature-content
-                                  comp-md content
+                                  comp-md content $ {} (:class-name |)
                       comp-md-block (inline-content! |content/intro.md)
-                        {} $ :highlight
-                          fn (code lang) (cirru-color/generateHtml code)
+                        {} (:class-name |)
+                          :highlight $ fn (code lang) (cirru-color/generateHtml code)
                       h2
                         {} $ :style ({})
                         <> |Ecosystem
@@ -98,8 +105,8 @@
                                       fn (idx link)
                                         [] idx $ comp-link link
                       comp-md-block (inline-content! |content/cirru.md)
-                        {} $ :highlight
-                          fn (code lang) (cirru-color/generateHtml code)
+                        {} (:class-name |)
+                          :highlight $ fn (code lang) (cirru-color/generateHtml code)
                       =< nil 120
                       div
                         {} $ :class-name css/row-parted
@@ -158,7 +165,7 @@
                     [] (&{} :name :match :title "|Pattern matching") (&{} :name :component :title |Component) (&{} :name :persistent-data :title "|Persistent data") (&{} :name :pipeline :title "|Pipeline macro")
                     fn (info d!)
                       d! cursor $ nth info 1
-                  comp-cirru-snippet $ trim (pick-demo state)
+                  comp-cirru-snippet-safe $ trim (pick-demo state)
           :examples $ []
           :schema $ :: 'Dynamic
         |comp-visual $ %{} 'CodeEntry (:doc |)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -28,14 +28,8 @@
               let
                   store $ read-field reel :store
                   states $ read-field store :states
-                  cursor $ either
-                      read-field states :cursor
-                      , states
-                    []
-                  state $ either
-                      read-field states :data
-                      , states
-                    {} $ :content |
+                  cursor $ either (read-field states :cursor) ([])
+                  state $ either (read-field states :data) ({})
                 div
                   {} $ :class-name (str-spaced css/preset css/global)
                   comp-bg
@@ -154,10 +148,7 @@
             defcomp comp-snippet-demo (states)
               let
                   cursor $ read-field states :cursor
-                  state $ either
-                      either (read-field states :data) :match
-                      , states
-                    , :match
+                  state $ either (read-field states :data) :match
                 div
                   {} (:class-name css/row)
                     :style $ {} (:flex-wrap :wrap)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -1,8 +1,8 @@
 
 {} (:about "|Machine-generated snapshot. Do not edit directly — changes will be overwritten. Use `cr query` to inspect and `cr edit`/`cr tree` to modify. Run `cr docs agents --full` first. Manual edits must follow format and schema conventions, then run `cr edit format`.") (:package |app) (:version |0.0.1)
   :entries $ {}
-    :default $ {} (:description |) (:init-fn 'app.main/main!) (:mode :native) (:reload-fn 'app.main/reload!)
-      :modules $ [] |respo.calcit/ |lilac/ |memof/ |respo-ui.calcit/ |respo-markdown.calcit/ |reel.calcit/
+    :default $ {} (:description |) (:init-fn 'app.main/main!) (:mode :js) (:reload-fn 'app.main/reload!)
+      :modules $ [] |respo.calcit/ |respo-ui.calcit/ |respo-markdown.calcit/ |reel.calcit/
       :type-slots $ {}
   :files $ {}
     |app.comp.container $ %{} 'FileEntry
@@ -448,7 +448,7 @@
         |doc-columns $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def doc-columns $ []
-              :: :column |Libraries $ [] (:: :link |Memof "|memoization library with caching" |https://github.com/calcit-lang/memof) (:: :link |Lilac "|validation library" |https://github.com/calcit-lang/lilac) (:: :link |Recollect "|Diff/patch library designed for Cumulo project" |https://github.com/calcit-lang/recollect) (:: :link "|Calcit WSS" "|WebSocket server binding" |https://github.com/calcit-lang/calcit-wss) (:: :link |Quaternion "|Quaternion math helper" |https://github.com/calcit-lang/quaternion) (:: :link |Std "|Some standard functions" |https://github.com/calcit-lang/calcit.std)
+              :: :column |Libraries $ [] (:: :link |Recollect "|Diff/patch library designed for Cumulo project" |https://github.com/calcit-lang/recollect) (:: :link "|Calcit WSS" "|WebSocket server binding" |https://github.com/calcit-lang/calcit-wss) (:: :link |Quaternion "|Quaternion math helper" |https://github.com/calcit-lang/quaternion) (:: :link |Std "|Some standard functions" |https://github.com/calcit-lang/calcit.std)
               :: :column |Frameworks $ [] (:: :link |Respo "|virtual DOM library" |https://github.com/Respo/respo.calcit) (:: :link |Cumulo "|template for tiny realtime apps" |https://github.com/Cumulo/calcium-workflow) (:: :link |Phlox "|virtual DOM like wrapper on top of PIXI" |https://github.com/Quamolit/phlox.calcit) (:: :link |Lagopus "|thin WebGPU abstraction" |https://github.com/Triadica/lagopus) (:: :link |Quamolit "|what if we make animations in React's way?" |https://github.com/Quamolit/quamolit.calcit) (:: :link |Quaterfoil "|thin virtual DOM wrapper over three.js" |https://github.com/Quamolit/quatrefoil.calcit)
               :: :column "|AI Agents" $ [] (:: :link "|Agents Guide (CalcitAgent.md)" nil |https://repo.calcit-lang.org/calcit/docs/CalcitAgent.md) (:: :link "|GitHub: calcit-lang/calcit" nil |https://github.com/calcit-lang/calcit) (:: :link "|WASM Playground (try snippets)" nil |http://repo.calcit-lang.org/calcit-wasm-play/) (:: :link "|Calcit 语言依赖命令行接入 AI 代码生成的探索" nil |https://www.bilibili.com/video/BV1Rbv6BtE48/) (:: :link "|猜想: 界面仔也算上下文工程师" nil |https://www.bilibili.com/video/BV1M6AVz5EtE/)
               :: :column |Tools $ [] (:: :link "|Calcit IR viewer" nil |https://github.com/calcit-lang/calcit-ir-viewer) (:: :link "|Calcit Error viewer" nil |https://github.com/calcit-lang/calcit-error-viewer) (:: :link "|Calcit binding for clipboard" nil |https://github.com/calcit-lang/calcit-clipboard) (:: :link "|Calcit JSON" "|JSON binding" |https://github.com/calcit-lang/calcit-json)

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -158,10 +158,7 @@
                     [] (&{} :name :match :title "|Pattern matching") (&{} :name :component :title |Component) (&{} :name :persistent-data :title "|Persistent data") (&{} :name :pipeline :title "|Pipeline macro")
                     fn (info d!)
                       d! cursor $ nth info 1
-                  comp-cirru-snippet
-                    trim $ pick-demo state
-                    {} $ :style
-                      {} (:flex 1) (:margin "|12px 0px")
+                  comp-cirru-snippet $ trim (pick-demo state)
           :examples $ []
           :schema $ :: 'Dynamic
         |comp-visual $ %{} 'CodeEntry (:doc |)

--- a/content/cirru.md
+++ b/content/cirru.md
@@ -1,14 +1,17 @@
-### Editors and AI Agents
+### Structural source, editors, and AI agents
 
-Calcit embraces structural editing and abstracts away raw syntax like indentations and brackets. The project AST is stored in the `calcit.cirru` snapshot, which `cr` can inspect and update safely.
+Calcit treats source as a typed, editable program tree rather than a bag of indentation and brackets. The project AST is stored in the `calcit.cirru` snapshot, and the current `cr` toolchain keeps edits anchored to that structure.
 
-To modify the codebase, Calcit offers a deterministic [CLI toolset](https://repo.calcit-lang.org/calcit/docs/CalcitAgent.md):
+Use the deterministic [CLI toolset](https://repo.calcit-lang.org/calcit/docs/CalcitAgent.md) to work in small, reviewable steps:
 
-- `cr query` - Search and navigate symbols, definitions, and code structures dynamically.
-- `cr tree` - Perform structural replacements and modifications (e.g. `cr tree replace`).
-- `cr edit` - Execute incremental changes locally inside namespaces.
-- `cr analyze` - Check types, weak-type debt, examples, and project structure before a change lands.
+- `cr docs agents --full` - Read the current agent and migration rules before editing.
+- `cr query` - Search definitions, usages, schemas, examples, tests, and type information.
+- `cr tree` - Replace, insert, move, wrap, or rewrite AST nodes without guessing paths.
+- `cr edit` - Update definitions, imports, entries, modules, examples, and attached tests.
+- `cr cursor` / `cr edit transaction` - Keep repeated edits anchored or apply multi-step changes atomically.
+- `cr analyze` - Check types, weak-type debt, deprecations, examples, and project structure.
+- `cr test` / `cr js` - Run selected tests or emit JavaScript when the target is a JS project.
 
-Because AST operations and type evidence are exposed to the command line, Calcit is friendly for AI coding agents to explore and edit. Instead of fighting space indentation in traditional files, agents can inspect a definition, apply a small tree mutation, and validate the result.
+The workflow is intentionally inspect → edit → verify: query a definition, preview a structural mutation, check the resulting types and examples, and only then run the project gate. Snapshot writes are serialized; use a transaction with an expected revision for atomic multi-step changes, or separate worktrees for parallel agents.
 
-You can also explore the code online with the [WASM Playground](http://repo.calcit-lang.org/calcit-wasm-play/) to try snippets interactively.
+For new APIs, prefer typed `Option<T>` and `Result<T>` over `?` parameters and `nil`. Only trailing consecutive `Option` parameters are omitted automatically and filled with `None`; non-trailing options remain explicit. Try the language online in the [WASM Playground](http://repo.calcit-lang.org/calcit-wasm-play/).

--- a/content/cirru.md
+++ b/content/cirru.md
@@ -1,13 +1,14 @@
 ### Editors and AI Agents
 
-Calcit embraces structural editing and abstracts away raw syntax like indentations and brackets. The project AST is stored in a snapshotted data format `compact.cirru`.
+Calcit embraces structural editing and abstracts away raw syntax like indentations and brackets. The project AST is stored in the `calcit.cirru` snapshot, which `cr` can inspect and update safely.
 
 To modify the codebase, Calcit offers a deterministic [CLI toolset](https://repo.calcit-lang.org/calcit/docs/CalcitAgent.md):
 
 - `cr query` - Search and navigate symbols, definitions, and code structures dynamically.
 - `cr tree` - Perform structural replacements and modifications (e.g. `cr tree replace`).
 - `cr edit` - Execute incremental changes locally inside namespaces.
+- `cr analyze` - Check types, weak-type debt, examples, and project structure before a change lands.
 
-Because ast operations are exposed to the command line, Calcit is extremely friendly for AI Code Agents to explore and edit. Instead of fighting space indentation in traditional files, bots can directly alter the tree.
+Because AST operations and type evidence are exposed to the command line, Calcit is friendly for AI coding agents to explore and edit. Instead of fighting space indentation in traditional files, agents can inspect a definition, apply a small tree mutation, and validate the result.
 
 You can also explore the code online with the [WASM Playground](http://repo.calcit-lang.org/calcit-wasm-play/) to try snippets interactively.

--- a/content/intro.md
+++ b/content/intro.md
@@ -1,19 +1,24 @@
-Calcit is a Rust interpreter and JavaScript code emitter inspired by ClojureScript. Calcit emits modern JavaScript ES Modules and keeps the same typed data model across native execution and generated code.
+Calcit is a Rust interpreter and JavaScript ES Module compiler inspired by ClojureScript. The same data model runs natively and in generated browser or Node.js code, so you can prototype with `cr` and ship through Vite without changing language semantics.
 
-The current 0.13 line adds a clearer typed foundation: `Struct` and `Enum` distinguish definitions from values, `Option` and `Result` make failure paths explicit, and trailing `Option` parameters can be omitted and receive `None` automatically. The `cr` CLI also provides structural query, analysis, and editing workflows designed for both humans and AI coding agents.
+Calcit 0.13.11 sharpens that foundation. Nominal `Struct` and `Enum` types describe data boundaries, `Option` and `Result` make absence and failure explicit, and inferred Option/Result methods keep pipelines readable. Trailing `Option` parameters can be omitted and receive `None`, reducing the need for `?` parameters and `nil`. Typed host-FFI contracts and static JavaScript field access extend those checks to application boundaries.
+
+The compiler also treats the source snapshot as a first-class program structure: strict Cirru EDN decoding, typed data-shape patches, readable type symbols, and improved type diagnostics make changes safer. `cr query`, `cr tree`, `cr edit`, cursor workflows, transactions, type analysis, examples, and attached tests give people and AI agents a deterministic way to inspect, change, and verify code.
 
 ## Install & Try
 
-You can [try Calcit WASM build online](http://repo.calcit-lang.org/calcit-wasm-play/) for simple snippets. And also install Calcit locally with Cargo:
+You can [try Calcit in the WASM Playground](http://repo.calcit-lang.org/calcit-wasm-play/) for simple snippets. Install the public Calcit tools locally with Cargo:
 
 ```bash
-cargo install calcit
+cargo install calcit --bin cr --bin caps
 ```
 
-Command line called `cr` is available, which stands for "Calcit Runner". Eval snippets via:
+`cr` is the Calcit Runner. Evaluate a snippet, run a snapshot once, or opt into watch mode explicitly:
 
 ```bash
 cr eval 'println "|a demo"'
+cr calcit.cirru       # run once
+cr -w calcit.cirru    # watch explicitly
+cr js                 # emit JavaScript ES Modules
 ```
 
 ```bash
@@ -39,4 +44,4 @@ println $ {}
 
 Ubuntu binaries can be found on [GitHub Releases](https://github.com/calcit-lang/calcit/releases) for running in CI environments.
 
-Calcit projects store their source in the `calcit.cirru` snapshot. It is not designed to be edited as ordinary text; use the rich set of terminal commands (`cr query`, `cr tree`, `cr edit`) to programmatically read and modify Calcit code. This also empowers AI coding assistants to interact with Calcit projects with high precision. Read more about using the CLI in the [Agents Guide](https://repo.calcit-lang.org/calcit/docs/CalcitAgent.md).
+Calcit projects store their source in the `calcit.cirru` snapshot (with `compact.cirru` retained for compatibility). It is a structured program representation: use `cr query`, `cr tree`, `cr edit`, `cr cursor`, and `cr edit transaction` to make precise changes, then run type analysis, examples, tests, or JavaScript codegen as appropriate. This gives AI coding assistants the same inspect-edit-verify loop as human maintainers. Read the [Agents Guide](https://repo.calcit-lang.org/calcit/docs/CalcitAgent.md) for the current workflow.

--- a/content/intro.md
+++ b/content/intro.md
@@ -1,4 +1,6 @@
-Calcit is an interpreter built with Rust, and also a JavaScript code emitter. It's inspired mostly by ClojureScript. Calcit-js emits JavaScript in ES Modules syntax.
+Calcit is a Rust interpreter and JavaScript code emitter inspired by ClojureScript. Calcit emits modern JavaScript ES Modules and keeps the same typed data model across native execution and generated code.
+
+The current 0.13 line adds a clearer typed foundation: `Struct` and `Enum` distinguish definitions from values, `Option` and `Result` make failure paths explicit, and trailing `Option` parameters can be omitted and receive `None` automatically. The `cr` CLI also provides structural query, analysis, and editing workflows designed for both humans and AI coding agents.
 
 ## Install & Try
 
@@ -37,4 +39,4 @@ println $ {}
 
 Ubuntu binaries can be found on [GitHub Releases](https://github.com/calcit-lang/calcit/releases) for running in CI environments.
 
-Calcit files are mostly stored in `compact.cirru` format, which is not designed to be edited via text editors directly. Instead, you can use the rich set of terminal commands (`cr query`, `cr tree`, `cr edit`) to programmatically read and modify Calcit code. This also empowers AI coding assistants to seamlessly interact with Calcit projects with high precision. Read more about using the CLI in the [Agents Guide](https://repo.calcit-lang.org/calcit/docs/CalcitAgent.md).
+Calcit projects store their source in the `calcit.cirru` snapshot. It is not designed to be edited as ordinary text; use the rich set of terminal commands (`cr query`, `cr tree`, `cr edit`) to programmatically read and modify Calcit code. This also empowers AI coding assistants to interact with Calcit projects with high precision. Read more about using the CLI in the [Agents Guide](https://repo.calcit-lang.org/calcit/docs/CalcitAgent.md).

--- a/deps.cirru
+++ b/deps.cirru
@@ -2,5 +2,5 @@
 {} (:calcit-version |0.13.11)
   :dependencies $ {} (|Respo/reel.calcit |0.6.6)
     |Respo/respo-markdown.calcit |0.4.22
-    |Respo/respo-ui.calcit |0.7.3
+    |Respo/respo-ui.calcit |0.7.5
     |Respo/respo.calcit |0.16.67

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,8 +1,8 @@
 
-{} (:calcit-version |0.12.47)
-  :dependencies $ {} (|Respo/reel.calcit |0.6.4)
-    |Respo/respo-markdown.calcit |0.4.13
-    |Respo/respo-ui.calcit |0.6.4
-    |Respo/respo.calcit |0.16.47
+{} (:calcit-version |0.13.11)
+  :dependencies $ {} (|Respo/reel.calcit |0.6.6)
+    |Respo/respo-markdown.calcit |0.4.22
+    |Respo/respo-ui.calcit |0.7.3
+    |Respo/respo.calcit |0.16.67
     |calcit-lang/lilac |0.5.1
-    |calcit-lang/memof |0.0.24
+    |calcit-lang/memof |0.0.26

--- a/deps.cirru
+++ b/deps.cirru
@@ -4,5 +4,3 @@
     |Respo/respo-markdown.calcit |0.4.22
     |Respo/respo-ui.calcit |0.7.3
     |Respo/respo.calcit |0.16.67
-    |calcit-lang/lilac |0.5.1
-    |calcit-lang/memof |0.0.26

--- a/history/202608121315-homepage-upgrade.md
+++ b/history/202608121315-homepage-upgrade.md
@@ -1,0 +1,5 @@
+## Homepage and dependency refresh
+
+- Align the site with Calcit 0.13.11 and the current module chain, including typed `Option`/`Result`, `Struct`/`Enum`, structural CLI analysis, and `calcit.cirru` snapshots.
+- Refresh Respo/Reel modules through `caps upgrade --all` and refresh the direct Yarn dependency set, keeping `@calcit/procs` on the same Calcit version.
+- Adapt the homepage's Reel state reads to `reel.schema/read-field` and pass an empty props map to Respo DOM helpers so the upgraded typed contracts compile cleanly.

--- a/history/202608121315-homepage-upgrade.md
+++ b/history/202608121315-homepage-upgrade.md
@@ -3,3 +3,4 @@
 - Align the site with Calcit 0.13.11 and the current module chain, including typed `Option`/`Result`, `Struct`/`Enum`, structural CLI analysis, and `calcit.cirru` snapshots.
 - Refresh Respo/Reel modules through `caps upgrade --all` and refresh the direct Yarn dependency set, keeping `@calcit/procs` on the same Calcit version.
 - Adapt the homepage's Reel state reads to `reel.schema/read-field` and pass an empty props map to Respo DOM helpers so the upgraded typed contracts compile cleanly.
+- Remove the superseded Lilac, Memof, and Calcit Test module references from the project dependency and ecosystem lists.

--- a/history/202608121340-vite-esm-config.md
+++ b/history/202608121340-vite-esm-config.md
@@ -1,0 +1,4 @@
+## Vite ESM configuration
+
+- Rename `vite.config.js` to `vite.config.mjs` so Vite detects the existing ESM `export default` configuration without the CommonJS/native config-loader warning.
+- Keep the production build configuration unchanged and verify with the current Vite version.

--- a/history/202608121410-snippet-options.md
+++ b/history/202608121410-snippet-options.md
@@ -1,0 +1,5 @@
+## Respo UI snippet compatibility
+
+- The upgraded Respo UI `comp-cirru-snippet` still reads optional options with legacy `get` semantics; passing a style map produced an Option where Respo expects a Map.
+- Use the component's supported one-argument form for the homepage snippet preview, avoiding the incompatible optional-options path.
+- Regenerated the Calcit JS output and verified the Vite production build.

--- a/history/202608121530-chrome-devtools-runtime.md
+++ b/history/202608121530-chrome-devtools-runtime.md
@@ -1,0 +1,5 @@
+## Chrome DevTools runtime compatibility check
+
+- Chrome DevTools reproduced the homepage failure: `respo-ui.comp/comp-cirru-snippet` and `respo-md.comp.md` called legacy `get` with omitted options, which the current Calcit runtime rejects.
+- Added a local plain-text snippet preview and passed explicit option maps to the homepage Markdown components, preserving code highlighting while avoiding nil/empty-option access.
+- Verified with `cr js`, `yarn vite build --base=./`, and Chrome DevTools on `http://localhost:5174/`; the page reports `App started.` with no runtime errors.

--- a/history/202608121550-snippet-tab-state.md
+++ b/history/202608121550-snippet-tab-state.md
@@ -1,0 +1,5 @@
+# 2026-08-12 15:50
+
+- 修复首页 snippets 标签切换状态未生效的问题。
+- 对照 Respo UI 的 `comp-demo-tabs`，在 `comp-tabs` 回调边界使用 `option:unwrap-or (nth info 1) nil` 解包 `TabRoute` 的 Option 值，再写入 Respo states。
+- 通过本地浏览器验证 Pattern matching 与 Component 标签及代码内容能够互相切换。

--- a/history/202608121700-calcit-01311-content.md
+++ b/history/202608121700-calcit-01311-content.md
@@ -1,0 +1,5 @@
+## Calcit 0.13.11 homepage refresh
+
+- Reviewed recent Calcit changes: nominal Struct/Enum data, Option-first absence APIs, omitted trailing Option parameters, inferred Option/Result methods, typed host-FFI contracts, static JavaScript field access, strict Cirru EDN workflows, structural data patches, and improved `cr` query/edit/test/analysis workflows.
+- Updated the homepage hero, feature cards, Markdown content, SEO metadata, and README to describe the current native + JavaScript ES Module workflow and inspect-edit-verify model.
+- Verified the snapshot with `cr js`, built with `yarn vite build --base=./`, and checked `http://localhost:5174/` in Chrome DevTools with no application runtime errors.

--- a/history/202608121820-upgrade-respo-ui-snippet.md
+++ b/history/202608121820-upgrade-respo-ui-snippet.md
@@ -1,0 +1,5 @@
+## Upgrade respo-ui snippet fix
+
+- Merged and released `Respo/respo-ui.calcit` 0.7.4 and follow-up 0.7.5. The component now uses `schema/read-field` and normalizes omitted options to `{}` before reading optional fields.
+- Updated this project to `respo-ui` 0.7.5 and removed the temporary local `comp-cirru-snippet-safe` workaround, restoring the official `comp-cirru-snippet` component.
+- Verified with `cr js`, `yarn vite build --base=./`, and Chrome DevTools; the page reports `App started.` with no application runtime errors.

--- a/index.html
+++ b/index.html
@@ -3,16 +3,16 @@
 
 <head>
   <meta charset="utf-8">
-  <title>Calcit Language</title>
-  <meta name="description" content="Calcit is a typed Lisp-inspired language with a Rust interpreter and JavaScript ES Modules emitter. It offers Option and Result types, Struct and Enum data, pattern matching, persistent collections, hot code swapping, and structural CLI tooling for AI coding agents.">
-  <meta name="keywords" content="Calcit, typed Lisp, Rust interpreter, JavaScript, ES Modules, Option, Result, Struct, Enum, AI coding agents, structural editing, pattern matching, persistent data, hot code swapping, ClojureScript">
-  <meta property="og:title" content="Calcit Language">
-  <meta property="og:description" content="Discover Calcit, a typed Lisp-inspired language with Option, Result, Struct, Enum, pattern matching, persistent data, and an AI-friendly structural CLI.">
+  <title>Calcit 0.13.11 — Typed Lisp for JavaScript ES Modules</title>
+  <meta name="description" content="Calcit is a typed Lisp-inspired language with a Rust interpreter and JavaScript ES Module compiler. Calcit 0.13.11 brings Struct, Enum, Option, Result, typed host FFI, structural cr tooling, and deterministic inspect-edit-verify workflows.">
+  <meta name="keywords" content="Calcit 0.13.11, typed Lisp, Rust interpreter, JavaScript, ES Modules, Option, Result, Struct, Enum, typed FFI, Cirru EDN, AI coding agents, cr CLI, structural editing, pattern matching, persistent data, ClojureScript">
+  <meta property="og:title" content="Calcit 0.13.11 — Typed Lisp for JavaScript ES Modules">
+  <meta property="og:description" content="Discover Calcit: typed Struct and Enum data, Option and Result APIs, typed host FFI, and a structural cr CLI for reliable JavaScript projects and AI-assisted development.">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://cdn.tiye.me/logo/calcit.png">
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="Calcit Language">
-  <meta name="twitter:description" content="Explore Calcit, a modern typed Lisp for JavaScript ES Modules with Option, Result, Struct, Enum, and structural CLI tooling.">
+  <meta name="twitter:title" content="Calcit 0.13.11 — Typed Lisp for JavaScript ES Modules">
+  <meta name="twitter:description" content="Explore Calcit 0.13.11: a modern typed Lisp with Struct, Enum, Option, Result, typed FFI, and structural cr tooling.">
   <meta name="twitter:image" content="https://cdn.tiye.me/logo/calcit.png">
   <link rel="icon" type="image/png" href="https://cdn.tiye.me/logo/calcit.png"/>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"/>

--- a/index.html
+++ b/index.html
@@ -4,15 +4,15 @@
 <head>
   <meta charset="utf-8">
   <title>Calcit Language</title>
-  <meta name="description" content="Calcit is a Lisp-inspired programming language that compiles to JavaScript ES Modules. It features an interpreter, hot code swapping, pattern matching, persistent data structures, and an indentation-based syntax.">
-  <meta name="keywords" content="Calcit, Lisp, JavaScript, ES Modules, functional programming, hot code swapping, pattern matching, persistent data, indentation-based syntax, ClojureScript">
+  <meta name="description" content="Calcit is a typed Lisp-inspired language with a Rust interpreter and JavaScript ES Modules emitter. It offers Option and Result types, Struct and Enum data, pattern matching, persistent collections, hot code swapping, and structural CLI tooling for AI coding agents.">
+  <meta name="keywords" content="Calcit, typed Lisp, Rust interpreter, JavaScript, ES Modules, Option, Result, Struct, Enum, AI coding agents, structural editing, pattern matching, persistent data, hot code swapping, ClojureScript">
   <meta property="og:title" content="Calcit Language">
-  <meta property="og:description" content="Discover Calcit, a Lisp-inspired language compiling to JavaScript ES Modules, offering hot code swapping, pattern matching, and more.">
+  <meta property="og:description" content="Discover Calcit, a typed Lisp-inspired language with Option, Result, Struct, Enum, pattern matching, persistent data, and an AI-friendly structural CLI.">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://cdn.tiye.me/logo/calcit.png">
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="Calcit Language">
-  <meta name="twitter:description" content="Explore Calcit, a modern Lisp for JavaScript ES Modules development with features like hot code swapping and persistent data.">
+  <meta name="twitter:description" content="Explore Calcit, a modern typed Lisp for JavaScript ES Modules with Option, Result, Struct, Enum, and structural CLI tooling.">
   <meta name="twitter:image" content="https://cdn.tiye.me/logo/calcit.png">
   <link rel="icon" type="image/png" href="https://cdn.tiye.me/logo/calcit.png"/>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"/>

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "dependencies": {
-    "@calcit/procs": "^0.12.47",
+    "@calcit/procs": "^0.13.11",
     "cirru-color": "^0.2.4",
     "copy-text-to-clipboard": "^3.2.2",
-    "dayjs": "^1.11.20"
+    "dayjs": "^1.11.21"
   },
   "devDependencies": {
     "bottom-tip": "^0.1.5",
-    "vite": "^8.0.11"
+    "vite": "^8.2.1"
   },
   "version": "0.0.1",
   "packageManager": "yarn@4.12.0"

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,4 +1,3 @@
-
 export default {
   build: {
     minify: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.12.47":
-  version: 0.12.47
-  resolution: "@calcit/procs@npm:0.12.47"
+"@calcit/procs@npm:^0.13.11":
+  version: 0.13.11
+  resolution: "@calcit/procs@npm:0.13.11"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/31a0874d2ea99759165e493b242578811e2fa392047eeb06b7a2c16a578986c1731d29077f92292e4a33449e295849ab43151a30f7a088ff993c71e683e4854c
+  checksum: 10c0/9126474441b8c9ad3113947fabb065bb36d0e4a70916c90a02657dce2904e6f341300d0510903ce67e80af95e7db72b87c28adae7318636f305a7d9e8df8389b
   languageName: node
   linkType: hard
 
@@ -37,52 +37,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/core@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@emnapi/core@npm:1.10.0"
-  dependencies:
-    "@emnapi/wasi-threads": "npm:1.2.1"
-    tslib: "npm:^2.4.0"
-  checksum: 10c0/f51d08227857b60632de7714d708124f0e100a1462dde6df8221760939aa3204a73193830371830fac0716f3ccd2129f2cac1b17cd7d7958bc4da9018a296edb
-  languageName: node
-  linkType: hard
-
-"@emnapi/runtime@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@emnapi/runtime@npm:1.10.0"
-  dependencies:
-    tslib: "npm:^2.4.0"
-  checksum: 10c0/953f14991d1aefb92ee6f8eb27dea725e484791a53a0cb5f47d9e0087b9a2c929ff2e92adf95af15d6ad456db6300c6b761ebf72b50a875b874a83520b3ba093
-  languageName: node
-  linkType: hard
-
-"@emnapi/wasi-threads@npm:1.2.1":
-  version: 1.2.1
-  resolution: "@emnapi/wasi-threads@npm:1.2.1"
-  dependencies:
-    tslib: "npm:^2.4.0"
-  checksum: 10c0/32fcfa81ab396533b2ec1f4082b1ff779a05d9c836bbbd3f4398405b0e6814c0d9503b7993130e37bc6941dbc1ded49f55e9700ae9ca4e803bab2b5bc5deb331
-  languageName: node
-  linkType: hard
-
 "@isaacs/fs-minipass@npm:^4.0.0":
   version: 4.0.1
   resolution: "@isaacs/fs-minipass@npm:4.0.1"
   dependencies:
     minipass: "npm:^7.0.4"
   checksum: 10c0/c25b6dc1598790d5b55c0947a9b7d111cfa92594db5296c3b907e2f533c033666f692a3939eadac17b1c7c40d362d0b0635dc874cbfe3e70db7c2b07cc97a5d2
-  languageName: node
-  linkType: hard
-
-"@napi-rs/wasm-runtime@npm:^1.1.4":
-  version: 1.1.4
-  resolution: "@napi-rs/wasm-runtime@npm:1.1.4"
-  dependencies:
-    "@tybys/wasm-util": "npm:^0.10.1"
-  peerDependencies:
-    "@emnapi/core": ^1.7.1
-    "@emnapi/runtime": ^1.7.1
-  checksum: 10c0/2e88e1955258949ccf2d18c79975821ad38071b465ef126a5e14110977b97868867b016c1ad046e963cccc42c0bd9db6c8ff5fd1ebb61b87bb3487f339041658
   languageName: node
   linkType: hard
 
@@ -108,135 +68,115 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oxc-project/types@npm:=0.128.0":
-  version: 0.128.0
-  resolution: "@oxc-project/types@npm:0.128.0"
-  checksum: 10c0/b6999b1b6b012d979364231a2c0c9204bca814a73f8417234edd39bf352a081779dad72aaf18ac60a676fb904c1408b63553e4e1230d7408a4f885002d66c809
+"@oxc-project/types@npm:=0.143.0":
+  version: 0.143.0
+  resolution: "@oxc-project/types@npm:0.143.0"
+  checksum: 10c0/f450bdc6ebd69b09b5d77c1ca45369f9e1a2b69d21f9dfcdaaa2379e8d5228bfdd014e77bef9bc21ca5fd118fb9e2213d30d8eb70299f03b1aac5ee1ab2802ba
   languageName: node
   linkType: hard
 
-"@rolldown/binding-android-arm64@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-android-arm64@npm:1.0.0-rc.18"
+"@rolldown/binding-android-arm64@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-android-arm64@npm:1.2.3"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-darwin-arm64@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.0-rc.18"
+"@rolldown/binding-darwin-arm64@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.2.3"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-darwin-x64@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-darwin-x64@npm:1.0.0-rc.18"
+"@rolldown/binding-darwin-x64@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-darwin-x64@npm:1.2.3"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-freebsd-x64@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.0-rc.18"
+"@rolldown/binding-freebsd-x64@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.2.3"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.0-rc.18"
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.2.3"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.0-rc.18"
+"@rolldown/binding-linux-arm64-gnu@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.2.3"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.0-rc.18"
+"@rolldown/binding-linux-arm64-musl@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.2.3"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-ppc64-gnu@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.0.0-rc.18"
+"@rolldown/binding-linux-ppc64-gnu@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.2.3"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.0-rc.18"
+"@rolldown/binding-linux-s390x-gnu@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.2.3"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.0-rc.18"
+"@rolldown/binding-linux-x64-gnu@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.2.3"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.0-rc.18"
+"@rolldown/binding-linux-x64-musl@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.2.3"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.0-rc.18"
+"@rolldown/binding-openharmony-arm64@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.2.3"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.0-rc.18"
-  dependencies:
-    "@emnapi/core": "npm:1.10.0"
-    "@emnapi/runtime": "npm:1.10.0"
-    "@napi-rs/wasm-runtime": "npm:^1.1.4"
-  conditions: cpu=wasm32
-  languageName: node
-  linkType: hard
-
-"@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.0-rc.18"
+"@rolldown/binding-win32-arm64-msvc@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.2.3"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.0-rc.18"
+"@rolldown/binding-win32-x64-msvc@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.2.3"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@rolldown/pluginutils@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "@rolldown/pluginutils@npm:1.0.0-rc.18"
-  checksum: 10c0/c09f2ebe53762df23b725f452a3f7ee45968824b062a38ec06054e368551e8c5e1874b0ef28143ff3b1b9d6d5ca60177a34378bdd672e899c3646fb8d0bd5aff
-  languageName: node
-  linkType: hard
-
-"@tybys/wasm-util@npm:^0.10.1":
-  version: 0.10.2
-  resolution: "@tybys/wasm-util@npm:0.10.2"
-  dependencies:
-    tslib: "npm:^2.4.0"
-  checksum: 10c0/26165bcd1fd7269f42d7fbe3de318f854a8968de8397e89fc9a423bb3e2da35a52150f382e6323b3367595beb16d9800a6f35971a5599daf76da1742ec3afc25
+"@rolldown/pluginutils@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@rolldown/pluginutils@npm:1.0.1"
+  checksum: 10c0/99d9b06d90196823e4d8c841f258db7a16e5dbba5824a2962b05d907b79f1ba929d56f22dd744fd530936e568c865ee56a719dc31e57e13bc0a8eb4764a8d8dd
   languageName: node
   linkType: hard
 
@@ -334,10 +274,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dayjs@npm:^1.11.20":
-  version: 1.11.20
-  resolution: "dayjs@npm:1.11.20"
-  checksum: 10c0/8af525e2aa100c8db9923d706c42b2b2d30579faf89456619413a5c10916efc92c2b166e193c27c02eb3174b30aa440ee1e7b72b0a2876b3da651d204db848a0
+"dayjs@npm:^1.11.21":
+  version: 1.11.21
+  resolution: "dayjs@npm:1.11.21"
+  checksum: 10c0/bd97dfdc4bfea3c66268635690313828b386faa040fbc1f829ff42a2bd748b72c9d9b3c8f9616ce9e61fcb78923f1461a462c969c54b1084458ae1b715898fb0
   languageName: node
   linkType: hard
 
@@ -556,99 +496,99 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lightningcss-android-arm64@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-android-arm64@npm:1.32.0"
+"lightningcss-android-arm64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-android-arm64@npm:1.33.0"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"lightningcss-darwin-arm64@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-darwin-arm64@npm:1.32.0"
+"lightningcss-darwin-arm64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-darwin-arm64@npm:1.33.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"lightningcss-darwin-x64@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-darwin-x64@npm:1.32.0"
+"lightningcss-darwin-x64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-darwin-x64@npm:1.33.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"lightningcss-freebsd-x64@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-freebsd-x64@npm:1.32.0"
+"lightningcss-freebsd-x64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-freebsd-x64@npm:1.33.0"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"lightningcss-linux-arm-gnueabihf@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-linux-arm-gnueabihf@npm:1.32.0"
+"lightningcss-linux-arm-gnueabihf@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-arm-gnueabihf@npm:1.33.0"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"lightningcss-linux-arm64-gnu@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-linux-arm64-gnu@npm:1.32.0"
+"lightningcss-linux-arm64-gnu@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-arm64-gnu@npm:1.33.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"lightningcss-linux-arm64-musl@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-linux-arm64-musl@npm:1.32.0"
+"lightningcss-linux-arm64-musl@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-arm64-musl@npm:1.33.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"lightningcss-linux-x64-gnu@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-linux-x64-gnu@npm:1.32.0"
+"lightningcss-linux-x64-gnu@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-x64-gnu@npm:1.33.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"lightningcss-linux-x64-musl@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-linux-x64-musl@npm:1.32.0"
+"lightningcss-linux-x64-musl@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-x64-musl@npm:1.33.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"lightningcss-win32-arm64-msvc@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-win32-arm64-msvc@npm:1.32.0"
+"lightningcss-win32-arm64-msvc@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-win32-arm64-msvc@npm:1.33.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"lightningcss-win32-x64-msvc@npm:1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss-win32-x64-msvc@npm:1.32.0"
+"lightningcss-win32-x64-msvc@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-win32-x64-msvc@npm:1.33.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"lightningcss@npm:^1.32.0":
-  version: 1.32.0
-  resolution: "lightningcss@npm:1.32.0"
+"lightningcss@npm:^1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss@npm:1.33.0"
   dependencies:
     detect-libc: "npm:^2.0.3"
-    lightningcss-android-arm64: "npm:1.32.0"
-    lightningcss-darwin-arm64: "npm:1.32.0"
-    lightningcss-darwin-x64: "npm:1.32.0"
-    lightningcss-freebsd-x64: "npm:1.32.0"
-    lightningcss-linux-arm-gnueabihf: "npm:1.32.0"
-    lightningcss-linux-arm64-gnu: "npm:1.32.0"
-    lightningcss-linux-arm64-musl: "npm:1.32.0"
-    lightningcss-linux-x64-gnu: "npm:1.32.0"
-    lightningcss-linux-x64-musl: "npm:1.32.0"
-    lightningcss-win32-arm64-msvc: "npm:1.32.0"
-    lightningcss-win32-x64-msvc: "npm:1.32.0"
+    lightningcss-android-arm64: "npm:1.33.0"
+    lightningcss-darwin-arm64: "npm:1.33.0"
+    lightningcss-darwin-x64: "npm:1.33.0"
+    lightningcss-freebsd-x64: "npm:1.33.0"
+    lightningcss-linux-arm-gnueabihf: "npm:1.33.0"
+    lightningcss-linux-arm64-gnu: "npm:1.33.0"
+    lightningcss-linux-arm64-musl: "npm:1.33.0"
+    lightningcss-linux-x64-gnu: "npm:1.33.0"
+    lightningcss-linux-x64-musl: "npm:1.33.0"
+    lightningcss-win32-arm64-msvc: "npm:1.33.0"
+    lightningcss-win32-x64-msvc: "npm:1.33.0"
   dependenciesMeta:
     lightningcss-android-arm64:
       optional: true
@@ -672,7 +612,7 @@ __metadata:
       optional: true
     lightningcss-win32-x64-msvc:
       optional: true
-  checksum: 10c0/70945bd55097af46fc9fab7f5ed09cd5869d85940a2acab7ee06d0117004a1d68155708a2d462531cea2fc3c67aefc9333a7068c80b0b78dd404c16838809e03
+  checksum: 10c0/ce1f8279fbae636dbf37fa6e7385d5f98ed881d72af3362f24afbd4685e19c1fcdfecf17e5dd77f2ebee3d0c23ade276230d85842d07292229a2cffba8ff20a3
   languageName: node
   linkType: hard
 
@@ -803,12 +743,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11":
-  version: 3.3.11
-  resolution: "nanoid@npm:3.3.11"
+"nanoid@npm:^3.3.17":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/40e7f70b3d15f725ca072dfc4f74e81fcf1fbb02e491cf58ac0c79093adc9b0a73b152bcde57df4b79cd097e13023d7504acb38404a4da7bc1cd8e887b82fe0b
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 
@@ -904,14 +844,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.14":
-  version: 8.5.14
-  resolution: "postcss@npm:8.5.14"
+"picomatch@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "picomatch@npm:4.0.5"
+  checksum: 10c0/947bc6b6e1ff1e6c5aaf95b107a0839d12802f4f7b867663f67d47accba939ca1cb582cf99dfc30438efa1c4648ac5990967e783e8929c36b03e8440704ef1bd
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.5.25":
+  version: 8.5.26
+  resolution: "postcss@npm:8.5.26"
   dependencies:
-    nanoid: "npm:^3.3.11"
+    nanoid: "npm:^3.3.17"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/48138207cf5ef5581be1bfe2cb65ccfe0ac75e43888ba045afc8ed6043d7b56aeb3b9a9fe5b353ff554be943cd0cc15d826ccb991525159175971e5ee8ab0237
+  checksum: 10c0/2bdafc00d96bd57b6649a52e458864a4bf58ee56cfdbe4aea1472b5cccc127e6c1ad653bd0bec50d211e650eb0b9270c80e1e72aff2e2fa40d9e7363234d6e43
   languageName: node
   linkType: hard
 
@@ -946,27 +893,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rolldown@npm:1.0.0-rc.18":
-  version: 1.0.0-rc.18
-  resolution: "rolldown@npm:1.0.0-rc.18"
+"rolldown@npm:~1.2.1":
+  version: 1.2.3
+  resolution: "rolldown@npm:1.2.3"
   dependencies:
-    "@oxc-project/types": "npm:=0.128.0"
-    "@rolldown/binding-android-arm64": "npm:1.0.0-rc.18"
-    "@rolldown/binding-darwin-arm64": "npm:1.0.0-rc.18"
-    "@rolldown/binding-darwin-x64": "npm:1.0.0-rc.18"
-    "@rolldown/binding-freebsd-x64": "npm:1.0.0-rc.18"
-    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.0.0-rc.18"
-    "@rolldown/binding-linux-arm64-gnu": "npm:1.0.0-rc.18"
-    "@rolldown/binding-linux-arm64-musl": "npm:1.0.0-rc.18"
-    "@rolldown/binding-linux-ppc64-gnu": "npm:1.0.0-rc.18"
-    "@rolldown/binding-linux-s390x-gnu": "npm:1.0.0-rc.18"
-    "@rolldown/binding-linux-x64-gnu": "npm:1.0.0-rc.18"
-    "@rolldown/binding-linux-x64-musl": "npm:1.0.0-rc.18"
-    "@rolldown/binding-openharmony-arm64": "npm:1.0.0-rc.18"
-    "@rolldown/binding-wasm32-wasi": "npm:1.0.0-rc.18"
-    "@rolldown/binding-win32-arm64-msvc": "npm:1.0.0-rc.18"
-    "@rolldown/binding-win32-x64-msvc": "npm:1.0.0-rc.18"
-    "@rolldown/pluginutils": "npm:1.0.0-rc.18"
+    "@oxc-project/types": "npm:=0.143.0"
+    "@rolldown/binding-android-arm64": "npm:1.2.3"
+    "@rolldown/binding-darwin-arm64": "npm:1.2.3"
+    "@rolldown/binding-darwin-x64": "npm:1.2.3"
+    "@rolldown/binding-freebsd-x64": "npm:1.2.3"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.2.3"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.2.3"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.2.3"
+    "@rolldown/binding-linux-ppc64-gnu": "npm:1.2.3"
+    "@rolldown/binding-linux-s390x-gnu": "npm:1.2.3"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.2.3"
+    "@rolldown/binding-linux-x64-musl": "npm:1.2.3"
+    "@rolldown/binding-openharmony-arm64": "npm:1.2.3"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.2.3"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.2.3"
+    "@rolldown/pluginutils": "npm:^1.0.0"
   dependenciesMeta:
     "@rolldown/binding-android-arm64":
       optional: true
@@ -992,15 +938,13 @@ __metadata:
       optional: true
     "@rolldown/binding-openharmony-arm64":
       optional: true
-    "@rolldown/binding-wasm32-wasi":
-      optional: true
     "@rolldown/binding-win32-arm64-msvc":
       optional: true
     "@rolldown/binding-win32-x64-msvc":
       optional: true
   bin:
-    rolldown: bin/cli.mjs
-  checksum: 10c0/699b8545a9a8b85ed4c639122163a6f46f84404fd88262bafa9549b01546744db625fd4425fceb4658c888de1671323170de1f837f6f6bb93e243e6e1d48c114
+    rolldown: ./bin/cli.mjs
+  checksum: 10c0/4dbeabc826e59877c7520b2ae1f48d0111e1d21865f5931ff3d184d33f02683e943e65eb24932128fc03701bbcde1b341f313b3fa7f8007368bd1b5e993265f0
   languageName: node
   linkType: hard
 
@@ -1008,12 +952,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.12.47"
+    "@calcit/procs": "npm:^0.13.11"
     bottom-tip: "npm:^0.1.5"
     cirru-color: "npm:^0.2.4"
     copy-text-to-clipboard: "npm:^3.2.2"
-    dayjs: "npm:^1.11.20"
-    vite: "npm:^8.0.11"
+    dayjs: "npm:^1.11.21"
+    vite: "npm:^8.2.1"
   languageName: unknown
   linkType: soft
 
@@ -1107,20 +1051,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyglobby@npm:^0.2.16":
-  version: 0.2.16
-  resolution: "tinyglobby@npm:0.2.16"
+"tinyglobby@npm:^0.2.17":
+  version: 0.2.17
+  resolution: "tinyglobby@npm:0.2.17"
   dependencies:
     fdir: "npm:^6.5.0"
     picomatch: "npm:^4.0.4"
-  checksum: 10c0/f2e09fd93dd95c41e522113b686ff6f7c13020962f8698a864a257f3d7737599afc47722b7ab726e12f8a813f779906187911ff8ee6701ede65072671a7e934b
-  languageName: node
-  linkType: hard
-
-"tslib@npm:^2.4.0":
-  version: 2.8.1
-  resolution: "tslib@npm:2.8.1"
-  checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
+  checksum: 10c0/7f7bb0f197c88bc4b20c231e0deca4240ca3bf313a88f5a7fee93a872b84966a4d50220947c0455ad07a60b3b360961c5b7fd979222aeb716a9f99b412002e4c
   languageName: node
   linkType: hard
 
@@ -1158,19 +1095,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^8.0.11":
-  version: 8.0.11
-  resolution: "vite@npm:8.0.11"
+"vite@npm:^8.2.1":
+  version: 8.2.1
+  resolution: "vite@npm:8.2.1"
   dependencies:
     fsevents: "npm:~2.3.3"
-    lightningcss: "npm:^1.32.0"
-    picomatch: "npm:^4.0.4"
-    postcss: "npm:^8.5.14"
-    rolldown: "npm:1.0.0-rc.18"
-    tinyglobby: "npm:^0.2.16"
+    lightningcss: "npm:^1.33.0"
+    picomatch: "npm:^4.0.5"
+    postcss: "npm:^8.5.25"
+    rolldown: "npm:~1.2.1"
+    tinyglobby: "npm:^0.2.17"
   peerDependencies:
     "@types/node": ^20.19.0 || >=22.12.0
-    "@vitejs/devtools": ^0.1.18
+    "@vitejs/devtools": ^0.4.0
     esbuild: ^0.27.0 || ^0.28.0
     jiti: ">=1.21.0"
     less: ^4.0.0
@@ -1211,7 +1148,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10c0/504ec6064761239e7063426dd123ea68cd540cb2d475bf72f5b1062313b9c79984831f56a20891ed5e08b2753d34171ee7a75cbadf9365e975d1f68634f0a10f
+  checksum: 10c0/e958dd07502deeb552f04dba59418ff1eb63183add416fd7a3e3badabf5d36edc6834b94c916f9f9233f976bb1671e3e9989d90e869059af07b0d43f7fc078c2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Refresh homepage messaging for Calcit 0.13.11: typed Option/Result, Struct/Enum, structural CLI analysis, and calcit.cirru snapshots.
- Upgrade Calcit modules with `caps upgrade --all` and direct Yarn dependencies, including @calcit/procs 0.13.11 and Vite 8.2.1.
- Adapt Reel state access to `reel.schema/read-field` and empty Respo props maps for the upgraded typed contracts.

## Validation

- `caps`
- `yarn install --immutable`
- `cr calcit.cirru --check-only`
- `cr calcit.cirru analyze check-types --summary-only`
- `cr calcit.cirru analyze weak-types --only schema-dynamic,code-dynamic --intent unresolved --summary-only`
- `cr js`
- `yarn vite build --base=./`
- `cr calcit.cirru docs check-md README.md --dep ./`
- `cr calcit.cirru docs check-md content/intro.md --dep ./`
- `cr calcit.cirru docs check-md content/cirru.md --dep ./`

The native entry is browser-specific and still cannot execute `js/document.querySelector`; the CI-targeted JS codegen and Vite build pass.