### PR TITLE
chore: upgrade calcit-lang.org to 0.13.12

### DIFF
--- a/202608121755-upgrade-blocker.md
+++ b/202608121755-upgrade-blocker.md
@@ -1,0 +1,5 @@
+# 2026-08-12 17:55
+
+- 已将本项目依赖与 `@calcit/procs` 升级到 Calcit 0.13.12，并从远端同步分支后在独立升级分支验证。
+- `cr --check-only` 暴露 `respo-ui.comp/comp-tabs` 的跨模块 `dispatch-op` type-slot 身份不一致；该问题属于上游 UI 模块契约，未在应用层添加临时包装绕过。
+- 当前还存在应用 `app.schema/Op` 与 `reel.calcit` 0.6.6 变体列表不一致的历史风险，需单独确认后再提交。

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,5 +1,5 @@
 
-{} (:calcit-version |0.13.11)
+{} (:calcit-version |0.13.12)
   :dependencies $ {} (|Respo/reel.calcit |0.6.6)
     |Respo/respo-markdown.calcit |0.4.22
     |Respo/respo-ui.calcit |0.7.5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@calcit/procs": "^0.13.11",
+    "@calcit/procs": "^0.13.12",
     "cirru-color": "^0.2.4",
     "copy-text-to-clipboard": "^3.2.2",
     "dayjs": "^1.11.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.13.11":
-  version: 0.13.11
-  resolution: "@calcit/procs@npm:0.13.11"
+"@calcit/procs@npm:^0.13.12":
+  version: 0.13.12
+  resolution: "@calcit/procs@npm:0.13.12"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/9126474441b8c9ad3113947fabb065bb36d0e4a70916c90a02657dce2904e6f341300d0510903ce67e80af95e7db72b87c28adae7318636f305a7d9e8df8389b
+  checksum: 10c0/3d340cc2f7ea8c6094612e26cfd7d15cca79e816ec3da96071ea8519c8e272df8b4e72a2ba9eced15aa8495dfe4f91f4fc937a707a5a7f02fde5afad7579a304
   languageName: node
   linkType: hard
 
@@ -952,7 +952,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.11"
+    "@calcit/procs": "npm:^0.13.12"
     bottom-tip: "npm:^0.1.5"
     cirru-color: "npm:^0.2.4"
     copy-text-to-clipboard: "npm:^3.2.2"


### PR DESCRIPTION
同步 Calcit 0.13.12 与 @calcit/procs 0.13.12。已恢复临时实验改动并记录当前阻塞：respo-ui.comp/comp-tabs 跨模块 dispatch-op type-slot 身份不一致，需上游模块修复后再让 check-only 全绿。