### PR TITLE
chore: upgrade Calcit to 0.13.15

### DIFF
--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -24,9 +24,19 @@ jobs:
 
       - uses: calcit-lang/setup-cr@0.0.9
 
+      - name: Validate Calcit snapshot and type baseline
+        run: |
+          caps --ci
+          yarn install --immutable
+          cr calcit.cirru edit format
+          git diff --exit-code -- calcit.cirru
+          cr calcit.cirru analyze check-types --summary-only --format json
+          cr calcit.cirru analyze weak-types --only schema-dynamic,code-dynamic --intent unresolved --summary-only --format json
+          cr calcit.cirru analyze deprecated --summary-only --format json
+
       - name: "compiles to js"
         run: >
-          caps --ci && cr js
+          cr js
           && yarn && yarn vite build --base=./
 
       - name: Deploy to server

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: "compiles to js"
         run: >
           cr js
-          && yarn && yarn vite build --base=./
+          && yarn vite build --base=./
 
       - name: Deploy to server
         id: deploy

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,6 +1,6 @@
 
-{} (:calcit-version |0.13.12)
+{} (:calcit-version |0.13.15)
   :dependencies $ {} (|Respo/reel.calcit |0.6.6)
     |Respo/respo-markdown.calcit |0.4.22
-    |Respo/respo-ui.calcit |0.7.5
-    |Respo/respo.calcit |0.16.67
+    |Respo/respo-ui.calcit |0.7.7
+    |Respo/respo.calcit |0.16.69

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@calcit/procs": "^0.13.12",
+    "@calcit/procs": "^0.13.15",
     "cirru-color": "^0.2.4",
     "copy-text-to-clipboard": "^3.2.2",
     "dayjs": "^1.11.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.13.12":
-  version: 0.13.12
-  resolution: "@calcit/procs@npm:0.13.12"
+"@calcit/procs@npm:^0.13.15":
+  version: 0.13.15
+  resolution: "@calcit/procs@npm:0.13.15"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/3d340cc2f7ea8c6094612e26cfd7d15cca79e816ec3da96071ea8519c8e272df8b4e72a2ba9eced15aa8495dfe4f91f4fc937a707a5a7f02fde5afad7579a304
+  checksum: 10c0/f37687aac090b2a286f916ea3c9d9cc173d4f606d1f02d5e57e192cbf375277a05bcd5f0a75d890b2827635dec9959034046ea626fda8900b8fe2c7f5c4c3e8a
   languageName: node
   linkType: hard
 
@@ -952,7 +952,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.12"
+    "@calcit/procs": "npm:^0.13.15"
     bottom-tip: "npm:^0.1.5"
     cirru-color: "npm:^0.2.4"
     copy-text-to-clipboard: "npm:^3.2.2"


### PR DESCRIPTION
Upgrade to Calcit 0.13.15:

- deps.cirru calcit-version 0.13.12 → 0.13.15; respo-ui 0.7.5 → 0.7.7; respo.calcit 0.16.67 → 0.16.69
- @calcit/procs synced to ^0.13.15
- CI now validates snapshot format and type reports (check-types/weak-types/deprecated)

Known blocker (upstream, not app code): `--check-only` reports a cross-module `dispatch-op` type-slot mismatch inside respo-ui.comp/comp-tabs (W_LOCAL_FN_ARG_TYPE_MISMATCH). JS codegen (`cr js`) passes; site build verified locally. Type debt baseline: check-types 35 none / 1 partial / 8 full; weak-types 42 unresolved hits; deprecated 0.