### PR TITLE
chore: upgrade Calcit to 0.13.16

### DIFF
--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -30,9 +30,38 @@ jobs:
           yarn install --immutable
           cr calcit.cirru edit format
           git diff --exit-code -- calcit.cirru
-          cr calcit.cirru analyze check-types --summary-only --format json
-          cr calcit.cirru analyze weak-types --only schema-dynamic,code-dynamic --intent unresolved --summary-only --format json
-          cr calcit.cirru analyze deprecated --summary-only --format json
+          mkdir -p .calcit/upgrade
+          cr calcit.cirru analyze check-types --summary-only --format json > .calcit/upgrade/check-types.json
+          cr calcit.cirru analyze weak-types --only schema-dynamic,code-dynamic,code-nil --intent unresolved,declared-optional --summary-only --format json > .calcit/upgrade/weak-types.json
+          cr calcit.cirru analyze deprecated --summary-only --format json > .calcit/upgrade/deprecated.json
+          python3 - <<'PY'
+          import json
+          def load(p):
+            d = json.load(open(p))
+            return d.get('data', {}).get('summary', d.get('data', {}))
+          ct = load('.calcit/upgrade/check-types.json')
+          wt = load('.calcit/upgrade/weak-types.json')
+          dep = load('.calcit/upgrade/deprecated.json')
+          base = json.load(open('config/calcit-upgrade-baseline.json'))
+          metrics = {
+            'typeFull': ct.get('levels', {}).get('full', 0),
+            'typeNone': ct.get('levels', {}).get('none', 0),
+            'typeNotFull': ct.get('levels', {}).get('partial', 0),
+            'schemaDynamic': wt.get('kinds', {}).get('schema-dynamic', 0),
+            'codeDynamic': wt.get('kinds', {}).get('code-dynamic', 0),
+            'codeNil': wt.get('kinds', {}).get('code-nil', 0),
+            'declaredOptional': wt.get('intents', {}).get('declared-optional', 0),
+            'deprecatedCalls': dep.get('calls', 0),
+          }
+          fail = []
+          for k, v in metrics.items():
+            if v > base[k]:
+              fail.append(f"{k}: current={v} baseline={base[k]}")
+          if fail:
+            print("BASELINE REGRESSION:", "; ".join(fail))
+            raise SystemExit(1)
+          print("baseline OK:", json.dumps(metrics))
+          PY
 
       - name: "compiles to js"
         run: >

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 
 .yarn/
 .DS_Store
+.calcit/upgrade

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -190,22 +190,22 @@
           :code $ quote
             def demo-component $ inline-content! |content/demo/comp.cirru
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'String
         |demo-match $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def demo-match $ inline-content! |content/demo/match.cirru
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'String
         |demo-persistent-data $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def demo-persistent-data $ inline-content! |content/demo/persistent-data.cirru
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'String
         |demo-pipeline $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def demo-pipeline $ inline-content! |content/demo/pipeline.cirru
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'String
         |inline-content! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defmacro inline-content! (path) (read-file path)
@@ -216,7 +216,9 @@
             defn pick-demo (k)
               case-default k demo-match (:match demo-match) (:pipeline demo-pipeline) (:component demo-component) (:persistent-data demo-persistent-data)
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Fn
+            {} (:return 'String)
+              :args $ [] 'Dynamic
         |style-bg $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defstyle style-bg $ {}

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -12,7 +12,9 @@
             defn add-link (title url)
               a $ {} (:inner-text title) (:class-name css/link) (:href url) (:target |_blank)
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Fn
+            {} (:return 'respo.schema/Component)
+              :args $ [] 'String 'String
         |comp-bg $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-bg ()
@@ -21,7 +23,9 @@
               div $ {}
                 :class-name $ str-spaced |tile style-bg
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Fn
+            {} (:return 'respo.schema/Component)
+              :args $ []
         |comp-container $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-container (reel)
@@ -108,7 +112,9 @@
                       =< nil 40
                   when dev? $ comp-reel (>> states :reel) reel ({})
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Fn
+            {} (:return 'respo.schema/Component)
+              :args $ [] 'Dynamic
         |comp-link $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-link (link)
@@ -120,7 +126,9 @@
                   if (not= sub-title |)
                     <> sub-title $ str-spaced css/font-fancy style-sub-title
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Fn
+            {} (:return 'respo.schema/Component)
+              :args $ [] 'Dynamic
         |comp-promotions $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-promotions () $ div
@@ -142,7 +150,9 @@
                   :class-name $ str-spaced css/button style-promo-button style-main-button
                   :on-click $ fn (e d!) (js/window.open |https://repo.calcit-lang.org/calcit/docs/CalcitAgent.md |_blank)
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Fn
+            {} (:return 'respo.schema/Component)
+              :args $ []
         |comp-snippet-demo $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-snippet-demo (states)
@@ -161,7 +171,9 @@
                         option:unwrap-or (nth info 1) nil
                   comp-cirru-snippet $ trim (pick-demo state)
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Fn
+            {} (:return 'respo.schema/Component)
+              :args $ [] 'Map
         |comp-visual $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defcomp comp-visual () $ div ({})
@@ -171,7 +183,9 @@
                   {} $ :display :flex
                 img $ {} (:class-name style-editor-img) (:src |https://cos-sh.tiye.me/cos-up/00c992c3061ed59d8c7d533b7a31433b-calcit-editor.png)
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Fn
+            {} (:return 'respo.schema/Component)
+              :args $ []
         |demo-component $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def demo-component $ inline-content! |content/demo/comp.cirru
@@ -334,16 +348,16 @@
               (exists? js/process) (= |true js/process.env.cdn)
               :else false
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Bool
         |dev? $ %{} 'CodeEntry (:doc |)
           :code $ quote (def dev? true)
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Bool
         |site $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def site $ {} (:dev-ui |http://localhost:8100/main-fonts.css) (:release-ui |http://cdn.tiye.me/favored-fonts/main-fonts.css) (:cdn-url |http://cdn.tiye.me/calcit-workflow/) (:title |Calcit) (:icon |http://cdn.tiye.me/logo/mvc-works.png) (:storage-key |workflow)
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'app.schema/SiteConfig
       :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns app.config)
     |app.main $ %{} 'FileEntry
@@ -380,18 +394,22 @@
               println "|App started."
               println "|@@@@@@@@@@@@@@@@\n@\n@  Well, code is not minified on purpose~\n@\n@   although it's still bundled with Vite.\n@\n@@@@@@@@@@@@@@@@"
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
         |mount-target $ %{} 'CodeEntry (:doc |)
           :code $ quote
             def mount-target $ js/document.querySelector |.app
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'String
         |persist-storage! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn persist-storage! () $ .setItem js/localStorage (:storage-key config/site)
               js/JSON.stringify $ to-cirru-edn (:store @*reel)
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
         |reload! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn reload! () $ if (nil? build-errors)
@@ -401,12 +419,16 @@
                 hud! |ok~ |Ok
               hud! |error build-errors
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
         |render-app! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn render-app! () $ render! mount-target (comp-container @*reel) dispatch!
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ []
         |repeat! $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn repeat! (duration cb)
@@ -415,12 +437,16 @@
                   repeat! (* 1000 duration) cb
                 * 1000 duration
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Fn
+            {} (:return 'Unit)
+              :args $ [] 'Number 'Fn
         |snippets $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defn snippets () $ println config/cdn?
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Fn
+            {} (:return 'String)
+              :args $ []
       :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.main $ :require
@@ -439,6 +465,11 @@
         |Op $ %{} 'CodeEntry (:doc |)
           :code $ quote
             defenum Op (:states 'List 'Dynamic) (:hydrate-storage 'Dynamic) (:reel/toggle) (:reel/recall 'Number) (:reel/merge) (:reel/reset) (:reel/step) (:reel/run) (:reel/remove 'Number)
+          :examples $ []
+          :schema $ :: 'Dynamic
+        |SiteConfig $ %{} 'CodeEntry (:doc |)
+          :code $ quote
+            defstruct SiteConfig (:dev-ui 'String) (:release-ui 'String) (:cdn-url 'String) (:title 'String) (:icon 'String) (:storage-key 'String)
           :examples $ []
           :schema $ :: 'Dynamic
         |doc-columns $ %{} 'CodeEntry (:doc |)
@@ -463,7 +494,7 @@
               :states $ {}
                 :cursor $ []
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Map
       :ns $ %{} 'NsEntry (:doc |)
         :code $ quote (ns app.schema)
     |app.updater $ %{} 'FileEntry
@@ -476,7 +507,9 @@
                 (:hydrate-storage d) d
                 _ $ do (eprintln "|Unknown op:" op) store
           :examples $ []
-          :schema $ :: 'Dynamic
+          :schema $ :: 'Fn
+            {} (:return 'Map)
+              :args $ [] 'Map 'Dynamic 'Dynamic 'Dynamic
       :ns $ %{} 'NsEntry (:doc |)
         :code $ quote
           ns app.updater $ :require

--- a/config/calcit-upgrade-baseline.json
+++ b/config/calcit-upgrade-baseline.json
@@ -1,0 +1,10 @@
+{
+  "typeFull": 24,
+  "typeNone": 14,
+  "typeNotFull": 7,
+  "schemaDynamic": 32,
+  "codeDynamic": 0,
+  "codeNil": 11,
+  "declaredOptional": 0,
+  "deprecatedCalls": 0
+}

--- a/deps.cirru
+++ b/deps.cirru
@@ -1,6 +1,6 @@
 
-{} (:calcit-version |0.13.15)
+{} (:calcit-version |0.13.16)
   :dependencies $ {} (|Respo/reel.calcit |0.6.6)
     |Respo/respo-markdown.calcit |0.4.22
     |Respo/respo-ui.calcit |0.7.7
-    |Respo/respo.calcit |0.16.69
+    |Respo/respo.calcit |0.16.70

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@calcit/procs": "^0.13.15",
+    "@calcit/procs": "^0.13.16",
     "cirru-color": "^0.2.4",
     "copy-text-to-clipboard": "^3.2.2",
     "dayjs": "^1.11.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.13.15":
-  version: 0.13.15
-  resolution: "@calcit/procs@npm:0.13.15"
+"@calcit/procs@npm:^0.13.16":
+  version: 0.13.17
+  resolution: "@calcit/procs@npm:0.13.17"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/f37687aac090b2a286f916ea3c9d9cc173d4f606d1f02d5e57e192cbf375277a05bcd5f0a75d890b2827635dec9959034046ea626fda8900b8fe2c7f5c4c3e8a
+  checksum: 10c0/78a57e550343b147fbecae44d31b09fa8f336dbe1419be42a93802db403ee22e721d3e73129c001b3bbd3a6a681159dc2c19512d7fd2728c875c9b8286b180b8
   languageName: node
   linkType: hard
 
@@ -952,7 +952,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.15"
+    "@calcit/procs": "npm:^0.13.16"
     bottom-tip: "npm:^0.1.5"
     cirru-color: "npm:^0.2.4"
     copy-text-to-clipboard: "npm:^3.2.2"


### PR DESCRIPTION
## Summary
- Upgrade Calcit to 0.13.16, respo to 0.16.70
- `cr js` codegen passes (existing respo-ui comp-tabs warning is non-blocking, same as 0.13.15)