### PR TITLE
chore: upgrade calcit to 0.13.19

### DIFF
--- a/deps.cirru
+++ b/deps.cirru
@@ -1,6 +1,6 @@
 
-{} (:calcit-version |0.13.16)
+{} (:calcit-version |0.13.19)
   :dependencies $ {} (|Respo/reel.calcit |0.6.6)
     |Respo/respo-markdown.calcit |0.4.22
     |Respo/respo-ui.calcit |0.7.7
-    |Respo/respo.calcit |0.16.70
+    |Respo/respo.calcit |0.16.72

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@calcit/procs": "^0.13.16",
+    "@calcit/procs": "^0.13.19",
     "cirru-color": "^0.2.4",
     "copy-text-to-clipboard": "^3.2.2",
     "dayjs": "^1.11.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@calcit/procs@npm:^0.13.16":
-  version: 0.13.17
-  resolution: "@calcit/procs@npm:0.13.17"
+"@calcit/procs@npm:^0.13.19":
+  version: 0.13.19
+  resolution: "@calcit/procs@npm:0.13.19"
   dependencies:
     "@calcit/ternary-tree": "npm:0.0.26"
     "@cirru/parser.ts": "npm:^0.0.9"
     "@cirru/writer.ts": "npm:^0.1.9"
-  checksum: 10c0/78a57e550343b147fbecae44d31b09fa8f336dbe1419be42a93802db403ee22e721d3e73129c001b3bbd3a6a681159dc2c19512d7fd2728c875c9b8286b180b8
+  checksum: 10c0/72f17208989f8e2e78462cce625b88fcb5c1635eb04a219f49c954a7c4abc7b0c1bce186d325978a4067d3840e02f3cbf913958828a5a4c543f00bc524c9a9fd
   languageName: node
   linkType: hard
 
@@ -952,7 +952,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@calcit/procs": "npm:^0.13.16"
+    "@calcit/procs": "npm:^0.13.19"
     bottom-tip: "npm:^0.1.5"
     cirru-color: "npm:^0.2.4"
     copy-text-to-clipboard: "npm:^3.2.2"


### PR DESCRIPTION
Per `cr docs read upgrade`: `caps upgrade --all` -> `:calcit-version` 0.13.19, deps bumped to latest tags, `@calcit/procs` synced to ^0.13.19. Branch based on `main`; local feature-branch state untouched.